### PR TITLE
Add corrected form templates

### DIFF
--- a/forms/e2_fixed.json
+++ b/forms/e2_fixed.json
@@ -1,0 +1,29 @@
+{
+  "id": "E2Fixed",
+  "description": "A sample form template2 with labels on info fields",
+  "fields": [
+    {
+      "label": "Intro",
+      "type": "info",
+      "text": "thankyou for taking the time to fill in this form"
+    },
+    {
+      "label": "Name",
+      "type": "text"
+    },
+    {
+      "label": "Age",
+      "type": "number"
+    },
+    {
+      "label": "Favorite Color",
+      "type": "dropdown",
+      "options": [
+        "orange",
+        "Red",
+        "Green",
+        "Blue"
+      ]
+    }
+  ]
+}

--- a/forms/survey_with_instructions_fixed.json
+++ b/forms/survey_with_instructions_fixed.json
@@ -1,0 +1,29 @@
+{
+  "id": "SurveyWithInstructionsFixed",
+  "description": "A survey that includes instructions and questions with labeled info fields",
+  "fields": [
+    {
+      "label": "Intro",
+      "type": "info",
+      "text": "Thank you for taking our survey! Please answer the questions below carefully."
+    },
+    {
+      "label": "First Name",
+      "type": "text"
+    },
+    {
+      "label": "Age",
+      "type": "number"
+    },
+    {
+      "label": "Fruit Instructions",
+      "type": "info",
+      "text": "Now choose your favorite fruits (you can pick more than one):"
+    },
+    {
+      "label": "Fruit Choices",
+      "type": "dropdown",
+      "options": ["Apple", "Banana", "Cherry"]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add corrected E2Fixed form with labeled info section
- add SurveyWithInstructionsFixed form with labeled instruction fields

## Testing
- `pytest`
- `python - <<'PY'
from app import app, TEMPLATES
client = app.test_client()

for form_id in ["E2Fixed", "SurveyWithInstructionsFixed"]:
    resp = client.get(f"/fill/{form_id}")
    print(form_id, 'GET', resp.status_code)
    template = TEMPLATES[form_id]
    post_data = {}
    for field in template["fields"]:
        label = field["label"]
        if field["type"] == "dropdown":
            post_data[label] = field["options"][0]
        else:
            post_data[label] = "test"
    resp = client.post(f"/fill/{form_id}", data=post_data, follow_redirects=True)
    print(form_id, 'POST', resp.status_code)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68947f0e3364832cb1799b76fdbc8b0e