### PR TITLE
Add helper text support to form templates

### DIFF
--- a/forms/example_template.json
+++ b/forms/example_template.json
@@ -2,12 +2,21 @@
   "name": "ExampleForm",
   "description": "A sample form template",
   "fields": [
-    { "label": "Name",            "type": "text" },
-    { "label": "Age",             "type": "number" },
+    {
+      "label": "Name",
+      "type": "text",
+      "help": "Enter your full name"
+    },
+    {
+      "label": "Age",
+      "type": "number",
+      "help": "Age in years"
+    },
     {
       "label": "Favorite Color",
       "type": "dropdown",
-      "options": ["Red", "Green", "Blue"]
+      "options": ["Red", "Green", "Blue"],
+      "help": "Select a color"
     }
   ]
 }

--- a/templates/edit_data.html
+++ b/templates/edit_data.html
@@ -16,6 +16,7 @@
             id="{{ field.label|replace(' ', '_') }}"
             name="{{ field.label }}"
             class="form-select flex-fill"
+            {% if field.help %}title="{{ field.help }}"{% endif %}
           >
             {% for opt in field.options %}
               <option value="{{ opt }}" {% if data[field.label] == opt %}selected{% endif %}>
@@ -31,6 +32,7 @@
             name="{{ field.label }}"
             class="form-control flex-fill"
             value="{{ data[field.label] }}"
+            {% if field.help %}placeholder="{{ field.help }}" title="{{ field.help }}"{% endif %}
           >
 
         {% elif field.type == 'textarea' %}
@@ -39,6 +41,7 @@
             name="{{ field.label }}"
             class="form-control flex-fill"
             rows="3"
+            {% if field.help %}placeholder="{{ field.help }}" title="{{ field.help }}"{% endif %}
           >{{ data[field.label] }}</textarea>
 
         {% else %}
@@ -48,6 +51,7 @@
             name="{{ field.label }}"
             class="form-control flex-fill"
             value="{{ data[field.label] }}"
+            {% if field.help %}placeholder="{{ field.help }}" title="{{ field.help }}"{% endif %}
           >
         {% endif %}
       </div>

--- a/templates/fill.html
+++ b/templates/fill.html
@@ -29,7 +29,13 @@
               id="{{ field.label|replace(' ', '_') }}"
               name="{{ field.label }}"
               class="form-select flex-fill"
+              {% if field.help %}title="{{ field.help }}"{% endif %}
             >
+              {% if field.help %}
+                <option value="" disabled {% if not request.form.get(field.label) %}selected{% endif %}>
+                  {{ field.help }}
+                </option>
+              {% endif %}
               {% for opt in field.options %}
                 <option value="{{ opt }}"
                   {% if request.form.get(field.label) == opt %}selected{% endif %}>
@@ -46,6 +52,7 @@
               name="{{ field.label }}"
               class="form-control flex-fill"
               value="{{ request.form.get(field.label, '') }}"
+              {% if field.help %}placeholder="{{ field.help }}" title="{{ field.help }}"{% endif %}
             >
 
           {# Multiline text area #}
@@ -55,6 +62,7 @@
               name="{{ field.label }}"
               class="form-control flex-fill"
               rows="3"
+              {% if field.help %}placeholder="{{ field.help }}" title="{{ field.help }}"{% endif %}
             >{{ request.form.get(field.label, '') }}</textarea>
 
           {# Default: single-line text input #}
@@ -65,6 +73,7 @@
               name="{{ field.label }}"
               class="form-control flex-fill"
               value="{{ request.form.get(field.label, '') }}"
+              {% if field.help %}placeholder="{{ field.help }}" title="{{ field.help }}"{% endif %}
             >
           {% endif %}
 


### PR DESCRIPTION
## Summary
- allow JSON field definitions to include `help` text
- display helper text as placeholders or tooltips in fill and edit forms
- document usage in the example template

## Testing
- `pytest`
- `python -m compileall -q .`


------
https://chatgpt.com/codex/tasks/task_e_68948ed4ebfc832caf5f784eab9b174b