### PR TITLE
Ensure helper text appears beneath form fields

### DIFF
--- a/templates/fill.html
+++ b/templates/fill.html
@@ -70,7 +70,7 @@
             {% endif %}
           </div>
           {% if field.help %}
-            <small class="text-muted">{{ field.help }}</small>
+            <div class="form-text text-muted">{{ field.help }}</div>
           {% endif %}
         </div>
       {% endif %}


### PR DESCRIPTION
## Summary
- Show field help messages on a separate line under inputs

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6894994f283c832ca3e1e5d57c779027