### PR TITLE
Ensure helper text appears on separate line

### DIFF
--- a/templates/fill.html
+++ b/templates/fill.html
@@ -15,21 +15,21 @@
 
       {# -- Otherwise render a label + control row -- #}
       {% else %}
-        <div class="mb-3">
-          <div class="d-flex align-items-center">
-            <label
-              for="{{ field.label|replace(' ', '_') }}"
-              style="width:150px; margin-right:0.75rem; font-weight:600;"
-            >
-              {{ field.label }}
-            </label>
+        <div class="mb-3 d-flex">
+          <label
+            for="{{ field.label|replace(' ', '_') }}"
+            style="width:150px; margin-right:0.75rem; font-weight:600;"
+          >
+            {{ field.label }}
+          </label>
 
+          <div class="flex-fill">
             {# Dropdown/select #}
             {% if field.type == 'dropdown' %}
               <select
                 id="{{ field.label|replace(' ', '_') }}"
                 name="{{ field.label }}"
-                class="form-select flex-fill"
+                class="form-select"
               >
                 {% for opt in field.options %}
                   <option value="{{ opt }}"
@@ -45,7 +45,7 @@
                 type="number"
                 id="{{ field.label|replace(' ', '_') }}"
                 name="{{ field.label }}"
-                class="form-control flex-fill"
+                class="form-control"
                 value="{{ request.form.get(field.label, '') }}"
               >
 
@@ -54,7 +54,7 @@
               <textarea
                 id="{{ field.label|replace(' ', '_') }}"
                 name="{{ field.label }}"
-                class="form-control flex-fill"
+                class="form-control"
                 rows="3"
               >{{ request.form.get(field.label, '') }}</textarea>
 
@@ -64,14 +64,15 @@
                 type="text"
                 id="{{ field.label|replace(' ', '_') }}"
                 name="{{ field.label }}"
-                class="form-control flex-fill"
+                class="form-control"
                 value="{{ request.form.get(field.label, '') }}"
               >
             {% endif %}
+
+            {% if field.help %}
+              <div class="form-text text-muted">{{ field.help }}</div>
+            {% endif %}
           </div>
-          {% if field.help %}
-            <div class="form-text text-muted">{{ field.help }}</div>
-          {% endif %}
         </div>
       {% endif %}
 


### PR DESCRIPTION
## Summary
- Wrap form inputs and helper text in a flex-fill container so helper text sits below the control

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6894a08b5528832cb37cb959689c885b