### PR TITLE
Add driverless API blueprint and SQLAlchemy models

### DIFF
--- a/api.py
+++ b/api.py
@@ -1,0 +1,121 @@
+from flask import Blueprint, request, jsonify, abort, Response
+from sqlalchemy import inspect, asc, desc
+from datetime import datetime
+import csv
+import io
+
+from database import db_session
+from database.models import Question
+
+api = Blueprint('api', __name__, url_prefix='/api')
+
+API_KEY = None
+
+def init_api(api_key: str | None = None):
+    global API_KEY
+    API_KEY = api_key
+
+def _require_api_key():
+    if API_KEY is None:
+        return
+    key = request.headers.get('X-API-KEY') or request.args.get('api_key')
+    if key != API_KEY:
+        abort(403, description='Invalid API key.')
+
+def _model_to_dict(obj):
+    mapper = inspect(obj).mapper
+    data = {}
+    for col in mapper.columns:
+        val = getattr(obj, col.key)
+        if hasattr(val, 'isoformat'):
+            data[col.key] = val.isoformat()
+        else:
+            data[col.key] = val
+    return data
+
+@api.route('/health')
+def health():
+    return jsonify({'status': 'ok', 'time': datetime.utcnow().isoformat() + 'Z'})
+
+@api.route('/questions', methods=['GET'])
+def get_questions():
+    _require_api_key()
+
+    q = db_session.query(Question)
+
+    search = request.args.get('search')
+    if search:
+        q = q.filter(
+            (Question.title.ilike(f'%{search}%')) |
+            (Question.text.ilike(f'%{search}%'))
+        )
+
+    updated_since = request.args.get('updated_since')
+    if updated_since:
+        ts = updated_since.replace('Z', '+00:00')
+        try:
+            dt = datetime.fromisoformat(ts)
+            q = q.filter(Question.updated_at >= dt)
+        except Exception:
+            abort(400, description='updated_since must be ISO8601 timestamp.')
+
+    sort = request.args.get('sort', 'id')
+    order = request.args.get('order', 'asc').lower()
+    col = getattr(Question, sort, None)
+    if col is None:
+        abort(400, description=f'Unsupported sort column: {sort}')
+    q = q.order_by(desc(col) if order == 'desc' else asc(col))
+
+    page = max(int(request.args.get('page', 1)), 1)
+    page_size = min(max(int(request.args.get('page_size', 100)), 1), 1000)
+    total = q.count()
+    rows = q.offset((page - 1) * page_size).limit(page_size).all()
+
+    data = [_model_to_dict(r) for r in rows]
+    return jsonify({
+        'page': page,
+        'page_size': page_size,
+        'total': total,
+        'items': data,
+    })
+
+@api.route('/questions/<int:item_id>', methods=['GET'])
+def get_question(item_id: int):
+    _require_api_key()
+    row = db_session.query(Question).get(item_id)
+    if not row:
+        abort(404)
+    return jsonify(_model_to_dict(row))
+
+@api.route('/questions.csv', methods=['GET'])
+def get_questions_csv():
+    _require_api_key()
+
+    q = db_session.query(Question)
+
+    search = request.args.get('search')
+    if search:
+        q = q.filter(
+            (Question.title.ilike(f'%{search}%')) |
+            (Question.text.ilike(f'%{search}%'))
+        )
+
+    q = q.order_by(asc(Question.id))
+
+    rows = q.all()
+    dicts = [_model_to_dict(r) for r in rows]
+
+    if not dicts:
+        csv_text = ''
+    else:
+        output = io.StringIO()
+        writer = csv.DictWriter(output, fieldnames=list(dicts[0].keys()))
+        writer.writeheader()
+        writer.writerows(dicts)
+        csv_text = output.getvalue()
+
+    return Response(
+        csv_text,
+        mimetype='text/csv',
+        headers={'Content-Disposition': 'attachment; filename=questions.csv'},
+    )

--- a/app.py
+++ b/app.py
@@ -4,6 +4,9 @@ from pathlib import Path
 from datetime import datetime
 import json
 from template_loader import load_templates
+from flask_cors import CORS
+from api import api, init_api
+from database import init_db as init_question_db
 
 # Load form templates and define paths
 FORMS_DIR = Path(__file__).parent / "forms"
@@ -13,6 +16,10 @@ DB_PATH = Path(__file__).parent / "database" / "forms.db"
 # Initialize Flask
 app = Flask(__name__)
 app.secret_key = "change-me"
+CORS(app, resources={r"/api/*": {"origins": "*"}})
+app.register_blueprint(api)
+init_api(api_key="REPLACE_WITH_LONG_RANDOM_VALUE")
+init_question_db()
 
 # Database helpers
 def init_db():

--- a/database/__init__.py
+++ b/database/__init__.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+from sqlalchemy import create_engine
+from sqlalchemy.orm import scoped_session, sessionmaker, declarative_base
+
+DB_FILE = Path(__file__).parent / 'forms.db'
+engine = create_engine(f'sqlite:///{DB_FILE}', connect_args={'check_same_thread': False})
+
+db_session = scoped_session(sessionmaker(bind=engine))
+Base = declarative_base()
+
+def init_db():
+    from . import models  # noqa: F401
+    Base.metadata.create_all(bind=engine)

--- a/database/models.py
+++ b/database/models.py
@@ -1,0 +1,12 @@
+from sqlalchemy import Column, Integer, String, Text, DateTime, func
+from . import Base
+
+
+class Question(Base):
+    __tablename__ = 'questions'
+
+    id = Column(Integer, primary_key=True)
+    title = Column(String(255), nullable=False)
+    text = Column(Text, nullable=False)
+    created_at = Column(DateTime, server_default=func.now(), nullable=False)
+    updated_at = Column(DateTime, server_default=func.now(), onupdate=func.now(), nullable=False)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,5 @@
 Flask==2.2.5
 Jinja2==3.1.2
+Flask-Cors==4.0.0
+SQLAlchemy==2.0.29
+Werkzeug==2.2.3


### PR DESCRIPTION
## Summary
- add questions API blueprint with CSV export and API-key auth
- wire blueprint, CORS, and API init into Flask app
- introduce SQLAlchemy setup and Question model

## Testing
- `python -m py_compile app.py api.py database/__init__.py database/models.py && echo 'py_compile passed'`
- `python - <<'PY'
from app import app
client = app.test_client()
resp = client.get('/api/health')
print('status', resp.status_code)
print('json', resp.get_json())
PY`
- `python - <<'PY'
from app import app
client = app.test_client()
resp = client.get('/api/questions', headers={'X-API-KEY':'REPLACE_WITH_LONG_RANDOM_VALUE'})
print('status', resp.status_code)
print('json', resp.get_json())
resp_csv = client.get('/api/questions.csv', headers={'X-API-KEY':'REPLACE_WITH_LONG_RANDOM_VALUE'})
print('csv', resp_csv.status_code, resp_csv.data.decode())
PY`


------
https://chatgpt.com/codex/tasks/task_e_68a642a4fd7c832c9c11c83aef8d35a9