### PR TITLE
Add API endpoints for completed forms

### DIFF
--- a/database/models.py
+++ b/database/models.py
@@ -10,3 +10,14 @@ class Question(Base):
     text = Column(Text, nullable=False)
     created_at = Column(DateTime, server_default=func.now(), nullable=False)
     updated_at = Column(DateTime, server_default=func.now(), onupdate=func.now(), nullable=False)
+
+
+class CompletedForm(Base):
+    """SQLAlchemy model for completed form submissions."""
+
+    __tablename__ = 'completed_forms'
+
+    id = Column(Integer, primary_key=True)
+    template_name = Column(String(255), nullable=False)
+    timestamp = Column(String, nullable=False)
+    form_json = Column(Text, nullable=False)


### PR DESCRIPTION
## Summary
- add SQLAlchemy model for completed form submissions
- expose `/api/forms` endpoints for listing, detail, and CSV export
- parse stored form JSON when returning API results

## Testing
- `python -m py_compile api.py database/models.py`
- `python - <<'PY' from app import app, init_db, save_completed_form; from api import init_api; init_db(); init_api(api_key=None); save_completed_form('sample', {'foo': 'bar'}); with app.test_client() as c: resp = c.get('/api/forms'); print('GET /api/forms status', resp.status_code); print('GET /api/forms json', resp.get_json()); fid = resp.get_json()['items'][0]['id']; resp2 = c.get(f'/api/forms/{fid}'); print('GET /api/forms/<id> status', resp2.status_code); print('GET /api/forms/<id> json', resp2.get_json())
PY`

------
https://chatgpt.com/codex/tasks/task_e_68a64c26cd50832c98c7415171b3f157