### PR TITLE
Handle templates with info/help fields

### DIFF
--- a/template_loader.py
+++ b/template_loader.py
@@ -10,6 +10,13 @@ def load_templates() -> dict[str, dict]:
             data = json.loads(file.read_text())
         except json.JSONDecodeError:
             continue
-        name = data.get("id", file.stem)
+
+        # Prefer explicit identifiers but fall back to the filename
+        name = data.get("id") or data.get("name") or file.stem
+
+        # Stash the source path so callers can map back to disk even if the
+        # template's `id` differs from the file name.
+        data["_file"] = file
+
         templates[name] = data
     return templates

--- a/templates/edit_data.html
+++ b/templates/edit_data.html
@@ -6,55 +6,59 @@
   <p class="text-muted">Originally submitted at {{ timestamp }}</p>
   <form method="post">
     {% for field in fields %}
-      <div class="mb-3 d-flex align-items-center">
-        <label for="{{ field.label|replace(' ', '_') }}" class="form-label me-3" style="width:150px;">
-          {{ field.label }}
-        </label>
+      {% if field.type == 'info' %}
+        <div class="alert alert-secondary">{{ field.text }}</div>
+      {% else %}
+        <div class="mb-3 d-flex align-items-center">
+          <label for="{{ field.label|replace(' ', '_') }}" class="form-label me-3" style="width:150px;">
+            {{ field.label }}
+          </label>
 
-        {% if field.type == 'dropdown' %}
-          <select
-            id="{{ field.label|replace(' ', '_') }}"
-            name="{{ field.label }}"
-            class="form-select flex-fill"
-            {% if field.help %}title="{{ field.help }}"{% endif %}
-          >
-            {% for opt in field.options %}
-              <option value="{{ opt }}" {% if data[field.label] == opt %}selected{% endif %}>
-                {{ opt }}
-              </option>
-            {% endfor %}
-          </select>
+          {% if field.type == 'dropdown' %}
+            <select
+              id="{{ field.label|replace(' ', '_') }}"
+              name="{{ field.label }}"
+              class="form-select flex-fill"
+              {% if field.help %}title="{{ field.help }}"{% endif %}
+            >
+              {% for opt in field.options %}
+                <option value="{{ opt }}" {% if data[field.label] == opt %}selected{% endif %}>
+                  {{ opt }}
+                </option>
+              {% endfor %}
+            </select>
 
-        {% elif field.type == 'number' %}
-          <input
-            type="number"
-            id="{{ field.label|replace(' ', '_') }}"
-            name="{{ field.label }}"
-            class="form-control flex-fill"
-            value="{{ data[field.label] }}"
-            {% if field.help %}placeholder="{{ field.help }}" title="{{ field.help }}"{% endif %}
-          >
+          {% elif field.type == 'number' %}
+            <input
+              type="number"
+              id="{{ field.label|replace(' ', '_') }}"
+              name="{{ field.label }}"
+              class="form-control flex-fill"
+              value="{{ data[field.label] }}"
+              {% if field.help %}placeholder="{{ field.help }}" title="{{ field.help }}"{% endif %}
+            >
 
-        {% elif field.type == 'textarea' %}
-          <textarea
-            id="{{ field.label|replace(' ', '_') }}"
-            name="{{ field.label }}"
-            class="form-control flex-fill"
-            rows="3"
-            {% if field.help %}placeholder="{{ field.help }}" title="{{ field.help }}"{% endif %}
-          >{{ data[field.label] }}</textarea>
+          {% elif field.type == 'textarea' %}
+            <textarea
+              id="{{ field.label|replace(' ', '_') }}"
+              name="{{ field.label }}"
+              class="form-control flex-fill"
+              rows="3"
+              {% if field.help %}placeholder="{{ field.help }}" title="{{ field.help }}"{% endif %}
+            >{{ data[field.label] }}</textarea>
 
-        {% else %}
-          <input
-            type="text"
-            id="{{ field.label|replace(' ', '_') }}"
-            name="{{ field.label }}"
-            class="form-control flex-fill"
-            value="{{ data[field.label] }}"
-            {% if field.help %}placeholder="{{ field.help }}" title="{{ field.help }}"{% endif %}
-          >
-        {% endif %}
-      </div>
+          {% else %}
+            <input
+              type="text"
+              id="{{ field.label|replace(' ', '_') }}"
+              name="{{ field.label }}"
+              class="form-control flex-fill"
+              value="{{ data[field.label] }}"
+              {% if field.help %}placeholder="{{ field.help }}" title="{{ field.help }}"{% endif %}
+            >
+          {% endif %}
+        </div>
+      {% endif %}
     {% endfor %}
     <button type="submit" class="btn btn-primary">Save Changes</button>
     <a href="{{ url_for('view_form', form_id=form_id) }}" class="btn btn-secondary ms-2">Cancel</a>


### PR DESCRIPTION
## Summary
- Track source file paths when loading templates so editing works even if the template `id` differs from the filename
- Skip unlabeled/info fields when processing or editing form data
- Render instructional `info` fields on the edit entry page

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `curl -I http://localhost:5000/edit-template/E2Fixed`


------
https://chatgpt.com/codex/tasks/task_e_68a6d5662634832c8aa867974cc02dd3