### PR TITLE
Fix info field layout and clean up templates

### DIFF
--- a/templates/edit_data.html
+++ b/templates/edit_data.html
@@ -7,70 +7,32 @@
   <form method="post">
     {% for field in fields %}
       {% if field.type == 'info' %}
-        <div class="alert alert-secondary">{{ field.text }}</div>
+        <div class="alert alert-secondary mb-3">{{ field.text }}</div>
       {% else %}
         <div class="mb-3 d-flex align-items-center">
           <label for="{{ field.label|replace(' ', '_') }}" class="form-label me-3" style="width:150px;">
             {{ field.label }}
           </label>
-
-          {% if field.type == 'dropdown' %}
-            <select
-              id="{{ field.label|replace(' ', '_') }}"
-              name="{{ field.label }}"
-              class="form-select flex-fill"
-              {% if field.help %}title="{{ field.help }}"{% endif %}
-            >
-              {% for opt in field.options %}
-                <option value="{{ opt }}" {% if data[field.label] == opt %}selected{% endif %}>
-                  {{ opt }}
-                </option>
-              {% endfor %}
-            </select>
-
-          {% elif field.type == 'number' %}
-            <input
-              type="number"
-              id="{{ field.label|replace(' ', '_') }}"
-              name="{{ field.label }}"
-              class="form-control flex-fill"
-              value="{{ data[field.label] }}"
-              {% if field.help %}placeholder="{{ field.help }}" title="{{ field.help }}"{% endif %}
-            >
-
-          {% elif field.type == 'textarea' %}
-            <textarea
-              id="{{ field.label|replace(' ', '_') }}"
-              name="{{ field.label }}"
-              class="form-control flex-fill"
-              rows="3"
-              {% if field.help %}placeholder="{{ field.help }}" title="{{ field.help }}"{% endif %}
-            >{{ data[field.label] }}</textarea>
-
-        {% else %}
-          <input
-            type="text"
-            id="{{ field.label|replace(' ', '_') }}"
-            name="{{ field.label }}"
-            class="form-control flex-fill"
-            value="{{ data[field.label] }}"
-            {% if field.help %}placeholder="{{ field.help }}" title="{{ field.help }}"{% endif %}
-          >
-        {% endif %}
-        {% if field.uom %}
-          <span class="ms-2">{{ field.uom }}</span>
-        {% endif %}
-      </div>
-
-          {% else %}
-            <input
-              type="text"
-              id="{{ field.label|replace(' ', '_') }}"
-              name="{{ field.label }}"
-              class="form-control flex-fill"
-              value="{{ data[field.label] }}"
-              {% if field.help %}placeholder="{{ field.help }}" title="{{ field.help }}"{% endif %}
-            >
+          <div class="flex-fill">
+            {% if field.type == 'dropdown' %}
+              <select id="{{ field.label|replace(' ', '_') }}" name="{{ field.label }}" class="form-select">
+                {% for opt in field.options %}
+                  <option value="{{ opt }}" {% if data[field.label] == opt %}selected{% endif %}>{{ opt }}</option>
+                {% endfor %}
+              </select>
+            {% elif field.type == 'number' %}
+              <input type="number" id="{{ field.label|replace(' ', '_') }}" name="{{ field.label }}" class="form-control" value="{{ data[field.label] }}">
+            {% elif field.type == 'textarea' %}
+              <textarea id="{{ field.label|replace(' ', '_') }}" name="{{ field.label }}" class="form-control" rows="3">{{ data[field.label] }}</textarea>
+            {% else %}
+              <input type="text" id="{{ field.label|replace(' ', '_') }}" name="{{ field.label }}" class="form-control" value="{{ data[field.label] }}">
+            {% endif %}
+            {% if field.help %}
+              <div class="form-text text-muted">{{ field.help }}</div>
+            {% endif %}
+          </div>
+          {% if field.uom %}
+            <span class="ms-2">{{ field.uom }}</span>
           {% endif %}
         </div>
       {% endif %}

--- a/templates/fill.html
+++ b/templates/fill.html
@@ -9,7 +9,7 @@
 
       {# -- Display-only info block -- #}
       {% if field.type == 'info' %}
-        <div class="alert alert-secondary">
+        <div class="alert alert-secondary mb-3">
           {{ field.text }}
         </div>
 


### PR DESCRIPTION
## Summary
- Ensure info fields render on their own line with spacing in fill and edit views
- Rewrite edit_data template to remove merge artefacts

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c7f1b26e40832c8bc5a52425f4e826