### PR TITLE
Place field help below form inputs

### DIFF
--- a/templates/edit_data.html
+++ b/templates/edit_data.html
@@ -9,30 +9,34 @@
       {% if field.type == 'info' %}
         <div class="alert alert-secondary mb-3">{{ field.text }}</div>
       {% else %}
-        <div class="mb-3 d-flex align-items-center">
-          <label for="{{ field.label|replace(' ', '_') }}" class="form-label me-3" style="width:150px;">
-            {{ field.label }}
-          </label>
-          <div class="flex-fill">
-            {% if field.type == 'dropdown' %}
-              <select id="{{ field.label|replace(' ', '_') }}" name="{{ field.label }}" class="form-select">
-                {% for opt in field.options %}
-                  <option value="{{ opt }}" {% if data[field.label] == opt %}selected{% endif %}>{{ opt }}</option>
-                {% endfor %}
-              </select>
-            {% elif field.type == 'number' %}
-              <input type="number" id="{{ field.label|replace(' ', '_') }}" name="{{ field.label }}" class="form-control" value="{{ data[field.label] }}">
-            {% elif field.type == 'textarea' %}
-              <textarea id="{{ field.label|replace(' ', '_') }}" name="{{ field.label }}" class="form-control" rows="3">{{ data[field.label] }}</textarea>
-            {% else %}
-              <input type="text" id="{{ field.label|replace(' ', '_') }}" name="{{ field.label }}" class="form-control" value="{{ data[field.label] }}">
-            {% endif %}
-            {% if field.help %}
-              <div class="form-text text-muted">{{ field.help }}</div>
+        <div class="mb-3">
+          <div class="d-flex align-items-center">
+            <label for="{{ field.label|replace(' ', '_') }}" class="form-label me-3" style="width:150px;">
+              {{ field.label }}
+            </label>
+            <div class="flex-fill">
+              {% if field.type == 'dropdown' %}
+                <select id="{{ field.label|replace(' ', '_') }}" name="{{ field.label }}" class="form-select">
+                  {% for opt in field.options %}
+                    <option value="{{ opt }}" {% if data[field.label] == opt %}selected{% endif %}>{{ opt }}</option>
+                  {% endfor %}
+                </select>
+              {% elif field.type == 'number' %}
+                <input type="number" id="{{ field.label|replace(' ', '_') }}" name="{{ field.label }}" class="form-control" value="{{ data[field.label] }}">
+              {% elif field.type == 'textarea' %}
+                <textarea id="{{ field.label|replace(' ', '_') }}" name="{{ field.label }}" class="form-control" rows="3">{{ data[field.label] }}</textarea>
+              {% else %}
+                <input type="text" id="{{ field.label|replace(' ', '_') }}" name="{{ field.label }}" class="form-control" value="{{ data[field.label] }}">
+              {% endif %}
+            </div>
+            {% if field.uom %}
+              <span class="ms-2">{{ field.uom }}</span>
             {% endif %}
           </div>
-          {% if field.uom %}
-            <span class="ms-2">{{ field.uom }}</span>
+          {% if field.help %}
+            <div class="form-text text-muted" style="margin-left:150px;">
+              {{ field.help }}
+            </div>
           {% endif %}
         </div>
       {% endif %}

--- a/templates/fill.html
+++ b/templates/fill.html
@@ -15,66 +15,69 @@
 
       {# -- Otherwise render a label + control row -- #}
       {% else %}
-        <div class="mb-3 d-flex align-items-center">
-          <label
-            for="{{ field.label|replace(' ', '_') }}"
-            style="width:150px; margin-right:0.75rem; font-weight:600;"
-          >
-            {{ field.label }}
-          </label>
+        <div class="mb-3">
+          <div class="d-flex align-items-center">
+            <label
+              for="{{ field.label|replace(' ', '_') }}"
+              style="width:150px; margin-right:0.75rem; font-weight:600;"
+            >
+              {{ field.label }}
+            </label>
 
-          <div class="flex-fill">
-            {# Dropdown/select #}
-            {% if field.type == 'dropdown' %}
-              <select
-                id="{{ field.label|replace(' ', '_') }}"
-                name="{{ field.label }}"
-                class="form-select"
-              >
-                {% for opt in field.options %}
-                  <option value="{{ opt }}"
-                    {% if request.form.get(field.label) == opt %}selected{% endif %}>
-                    {{ opt }}
-                  </option>
-                {% endfor %}
-              </select>
+            <div class="flex-fill">
+              {# Dropdown/select #}
+              {% if field.type == 'dropdown' %}
+                <select
+                  id="{{ field.label|replace(' ', '_') }}"
+                  name="{{ field.label }}"
+                  class="form-select"
+                >
+                  {% for opt in field.options %}
+                    <option value="{{ opt }}"
+                      {% if request.form.get(field.label) == opt %}selected{% endif %}>
+                      {{ opt }}
+                    </option>
+                  {% endfor %}
+                </select>
 
-            {# Number input #}
-            {% elif field.type == 'number' %}
-              <input
-                type="number"
-                id="{{ field.label|replace(' ', '_') }}"
-                name="{{ field.label }}"
-                class="form-control"
-                value="{{ request.form.get(field.label, '') }}"
-              >
+              {# Number input #}
+              {% elif field.type == 'number' %}
+                <input
+                  type="number"
+                  id="{{ field.label|replace(' ', '_') }}"
+                  name="{{ field.label }}"
+                  class="form-control"
+                  value="{{ request.form.get(field.label, '') }}"
+                >
 
-            {# Multiline text area #}
-            {% elif field.type == 'textarea' %}
-              <textarea
-                id="{{ field.label|replace(' ', '_') }}"
-                name="{{ field.label }}"
-                class="form-control"
-                rows="3"
-              >{{ request.form.get(field.label, '') }}</textarea>
+              {# Multiline text area #}
+              {% elif field.type == 'textarea' %}
+                <textarea
+                  id="{{ field.label|replace(' ', '_') }}"
+                  name="{{ field.label }}"
+                  class="form-control"
+                  rows="3"
+                >{{ request.form.get(field.label, '') }}</textarea>
 
-            {# Default: single-line text input #}
-            {% else %}
-              <input
-                type="text"
-                id="{{ field.label|replace(' ', '_') }}"
-                name="{{ field.label }}"
-                class="form-control"
-                value="{{ request.form.get(field.label, '') }}"
-              >
-            {% endif %}
-
-            {% if field.help %}
-              <div class="form-text text-muted">{{ field.help }}</div>
+              {# Default: single-line text input #}
+              {% else %}
+                <input
+                  type="text"
+                  id="{{ field.label|replace(' ', '_') }}"
+                  name="{{ field.label }}"
+                  class="form-control"
+                  value="{{ request.form.get(field.label, '') }}"
+                >
+              {% endif %}
+            </div>
+            {% if field.uom %}
+              <span class="ms-2">{{ field.uom }}</span>
             {% endif %}
           </div>
-          {% if field.uom %}
-            <span class="ms-2">{{ field.uom }}</span>
+          {% if field.help %}
+            <div class="form-text text-muted" style="margin-left:150px; margin-right:0.75rem;">
+              {{ field.help }}
+            </div>
           {% endif %}
         </div>
       {% endif %}


### PR DESCRIPTION
## Summary
- Relocate per-field help text beneath the main form row so labels and inputs stay compact
- Apply same layout to edit view to keep help advice unobtrusive

## Testing
- `pytest >/tmp/pytest.log; tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_68c7f38bfbdc832c84ca952fe4f3f4cd