### PR TITLE
Display help text beneath form fields

### DIFF
--- a/app.py
+++ b/app.py
@@ -112,7 +112,9 @@ def view_form(form_id):
     _, template_name, timestamp, form_json = row
     data = json.loads(form_json)
     tmpl = TEMPLATES.get(template_name, {})
-    units = {f["label"]: f.get("uom") for f in tmpl.get("fields", [])}
+    fields = tmpl.get("fields", [])
+    units = {f["label"]: f.get("uom") for f in fields if "label" in f}
+    helps = {f["label"]: f.get("help") for f in fields if "label" in f}
     return render_template(
         "view.html",
         id=form_id,
@@ -120,6 +122,8 @@ def view_form(form_id):
         timestamp=timestamp,
         data=data,
         units=units,
+        helps=helps,
+        fields=fields,
     )
 
 @app.route("/upload", methods=["GET", "POST"])

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -33,8 +33,6 @@ main {
 /* Form styles */
 form div {
   margin-bottom: 1rem;
-  display: flex;
-  align-items: center;
 }
 form label {
   width: 150px;

--- a/templates/view.html
+++ b/templates/view.html
@@ -3,12 +3,22 @@
 {% block content %}
   <h1>Form #{{ id }}: {{ template_name }}</h1>
   <p>Submitted at {{ timestamp }}</p>
-  <ul>
-    {% for k, v in data.items() %}
-      <li>{{ k }}: {{ v }}{% if units.get(k) %} {{ units.get(k) }}{% endif %}</li>
-    {% endfor %}
-  </ul>
+
+  {% for field in fields %}
+    {% if field.type == 'info' %}
+      <div class="alert alert-secondary mb-3">{{ field.text }}</div>
+    {% elif field.label %}
+      <div class="mb-3">
+        <strong>{{ field.label }}:</strong>
+        {{ data.get(field.label, '') }}{% if units.get(field.label) %} {{ units.get(field.label) }}{% endif %}
+        {% if helps.get(field.label) %}
+          <div class="form-text text-muted">{{ helps.get(field.label) }}</div>
+        {% endif %}
+      </div>
+    {% endif %}
+  {% endfor %}
 
   <h2>Raw JSON</h2>
   <pre>{{ data | tojson(indent=2) }}</pre>
 {% endblock %}
+


### PR DESCRIPTION
## Summary
- Ensure help text is shown under inputs by removing global flex styling
- Pass template field help info into view page
- Render help text for each field when viewing submissions

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c7f9918a50832cbd80cbb52317f8eb