### PR TITLE
Improve form layout and template editor

### DIFF
--- a/app.py
+++ b/app.py
@@ -172,12 +172,18 @@ def edit_template(template_name):
         except json.JSONDecodeError as e:
             flash(f"Invalid JSON: {e}", "danger")
 
-    # GET: show current JSON
+    # GET: show current template fields
     current = Path(file_path).read_text()
+    try:
+        template_data = json.loads(current)
+    except json.JSONDecodeError:
+        template_data = {}
+    if "fields" not in template_data:
+        template_data["fields"] = []
     return render_template(
         "edit_template.html",
         template_name=template_name,
-        current_json=current
+        template=template_data
     )
 
 @app.route("/edit-data/<int:form_id>", methods=["GET", "POST"])

--- a/templates/edit_template.html
+++ b/templates/edit_template.html
@@ -3,18 +3,109 @@
 {% block content %}
 <main class="container my-4">
   <h1>Edit Template: {{ template_name }}</h1>
-  <form method="post">
-    <div class="mb-3">
-      <label for="template_json" class="form-label">Template JSON</label>
-      <textarea
-        id="template_json"
-        name="template_json"
-        rows="20"
-        class="form-control font-monospace"
-      >{{ current_json }}</textarea>
+  <form method="post" id="template-form">
+    <div id="fields-container">
+      {% for field in template.fields %}
+      <div class="mb-3 field-block" data-index="{{ loop.index0 }}">
+        <div class="row g-2 align-items-center">
+          <div class="col-md-3">
+            <input type="text" class="form-control" name="label_{{ loop.index0 }}" placeholder="Label" value="{{ field.get('label','') }}">
+          </div>
+          <div class="col-md-3">
+            <select class="form-select" name="type_{{ loop.index0 }}">
+              <option value="text" {% if field.get('type')=='text' %}selected{% endif %}>text</option>
+              <option value="number" {% if field.get('type')=='number' %}selected{% endif %}>number</option>
+              <option value="textarea" {% if field.get('type')=='textarea' %}selected{% endif %}>textarea</option>
+              <option value="dropdown" {% if field.get('type')=='dropdown' %}selected{% endif %}>dropdown</option>
+              <option value="info" {% if field.get('type')=='info' %}selected{% endif %}>info</option>
+            </select>
+          </div>
+          <div class="col-md-3">
+            <input type="text" class="form-control" name="uom_{{ loop.index0 }}" placeholder="UOM" value="{{ field.get('uom','') }}">
+          </div>
+          <div class="col-md-3">
+            <input type="text" class="form-control" name="options_{{ loop.index0 }}" placeholder="Options (comma separated)" value="{% if field.get('options') %}{{ field.get('options')|join(', ') }}{% endif %}">
+          </div>
+        </div>
+        <div class="mt-1">
+          <textarea class="form-control" name="help_{{ loop.index0 }}" rows="2" placeholder="Help text">{{ field.get('help','') }}</textarea>
+        </div>
+      </div>
+      {% endfor %}
     </div>
+
+    <div class="mb-3">
+      <button type="button" class="btn btn-secondary btn-sm" id="add-field">Add Field</button>
+    </div>
+
+    <input type="hidden" name="template_json" id="template_json">
     <button type="submit" class="btn btn-primary">Save Template</button>
     <a href="{{ url_for('template_list') }}" class="btn btn-secondary ms-2">Cancel</a>
   </form>
 </main>
+
+<script>
+  document.addEventListener('DOMContentLoaded', function () {
+    let fieldIndex = {{ template.fields|length }};
+    const container = document.getElementById('fields-container');
+
+    document.getElementById('add-field').addEventListener('click', function () {
+      const idx = fieldIndex++;
+      const block = document.createElement('div');
+      block.className = 'mb-3 field-block';
+      block.dataset.index = idx;
+      block.innerHTML = `
+        <div class="row g-2 align-items-center">
+          <div class="col-md-3">
+            <input type="text" class="form-control" name="label_${idx}" placeholder="Label">
+          </div>
+          <div class="col-md-3">
+            <select class="form-select" name="type_${idx}">
+              <option value="text">text</option>
+              <option value="number">number</option>
+              <option value="textarea">textarea</option>
+              <option value="dropdown">dropdown</option>
+              <option value="info">info</option>
+            </select>
+          </div>
+          <div class="col-md-3">
+            <input type="text" class="form-control" name="uom_${idx}" placeholder="UOM">
+          </div>
+          <div class="col-md-3">
+            <input type="text" class="form-control" name="options_${idx}" placeholder="Options (comma separated)">
+          </div>
+        </div>
+        <div class="mt-1">
+          <textarea class="form-control" name="help_${idx}" rows="2" placeholder="Help text"></textarea>
+        </div>
+      `;
+      container.appendChild(block);
+    });
+
+    document.getElementById('template-form').addEventListener('submit', function (e) {
+      const fields = [];
+      document.querySelectorAll('.field-block').forEach(block => {
+        const idx = block.dataset.index;
+        const label = block.querySelector(`[name="label_${idx}"]`).value.trim();
+        const type = block.querySelector(`[name="type_${idx}"]`).value;
+        const uom = block.querySelector(`[name="uom_${idx}"]`).value.trim();
+        const optionsVal = block.querySelector(`[name="options_${idx}"]`).value.trim();
+        const help = block.querySelector(`[name="help_${idx}"]`).value.trim();
+        if (!label) return; // skip empty entries
+        const f = { label: label, type: type };
+        if (uom) f.uom = uom;
+        if (help) f.help = help;
+        if (optionsVal) {
+          f.options = optionsVal.split(',').map(o => o.trim()).filter(Boolean);
+        }
+        fields.push(f);
+      });
+
+      const tmpl = {{ template|tojson }};
+      tmpl.fields = fields;
+      document.getElementById('template_json').value = JSON.stringify(tmpl, null, 2);
+    });
+  });
+</script>
 {% endblock %}
+

--- a/templates/fill.html
+++ b/templates/fill.html
@@ -6,25 +6,20 @@
 
   <form method="post">
     {% for field in fields %}
-
       {# -- Display-only info block -- #}
       {% if field.type == 'info' %}
         <div class="alert alert-secondary mb-3">
           {{ field.text }}
         </div>
-
-      {# -- Otherwise render a label + control row -- #}
       {% else %}
         <div class="mb-3">
-          <div class="d-flex align-items-center">
-            <label
-              for="{{ field.label|replace(' ', '_') }}"
-              style="width:150px; margin-right:0.75rem; font-weight:600;"
-            >
-              {{ field.label }}
-            </label>
-
-            <div class="flex-fill">
+          <div class="row g-2 align-items-center">
+            <div class="col-md-3">
+              <label for="{{ field.label|replace(' ', '_') }}" class="col-form-label fw-semibold">
+                {{ field.label }}
+              </label>
+            </div>
+            <div class="col">
               {# Dropdown/select #}
               {% if field.type == 'dropdown' %}
                 <select
@@ -33,8 +28,7 @@
                   class="form-select"
                 >
                   {% for opt in field.options %}
-                    <option value="{{ opt }}"
-                      {% if request.form.get(field.label) == opt %}selected{% endif %}>
+                    <option value="{{ opt }}" {% if request.form.get(field.label) == opt %}selected{% endif %}>
                       {{ opt }}
                     </option>
                   {% endfor %}
@@ -71,19 +65,21 @@
               {% endif %}
             </div>
             {% if field.uom %}
-              <span class="ms-2">{{ field.uom }}</span>
+              <div class="col-md-2 col-auto">
+                <span>{{ field.uom }}</span>
+              </div>
             {% endif %}
           </div>
           {% if field.help %}
-            <div class="form-text text-muted" style="margin-left:150px; margin-right:0.75rem;">
-              {{ field.help }}
+            <div class="row">
+              <div class="col-md-9 offset-md-3">
+                <div class="form-text text-muted">{{ field.help }}</div>
+              </div>
             </div>
           {% endif %}
         </div>
       {% endif %}
-
     {% endfor %}
-
     <button type="submit" class="btn btn-primary">Submit</button>
   </form>
 </main>


### PR DESCRIPTION
## Summary
- Show label, input control, and unit on a single row when filling forms, with help text beneath
- Replace JSON textarea with structured field editor for templates and allow adding new fields
- Adjust backend to parse template JSON and supply field data to the editor

## Testing
- `pytest`
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68c800ebf3d0832cbd238872aa28db7d