### PR TITLE
Fix form field layout to stop wrapping

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1,3 +1,4 @@
+
 /* Base page styles */
 body {
   font-family: Arial, sans-serif;
@@ -30,22 +31,29 @@ main {
   box-shadow: 0 2px 4px rgba(0,0,0,0.1);
 }
 
-/* Form styles */
-form div {
+/* Form styles
+ *
+ * These rules apply only to forms that opt-in with the
+ * `.simple-form` class.  Bootstrap-based forms used elsewhere in
+ * the application rely on Bootstrap's own styling, so limiting the
+ * scope here prevents our base styles from overriding the grid
+ * layout and causing fields to stack vertically.
+ */
+.simple-form div {
   margin-bottom: 1rem;
 }
-form label {
+.simple-form label {
   width: 150px;
   margin-right: 0.5rem;
   font-weight: bold;
 }
-form input {
+.simple-form input {
   flex: 1;
   padding: 0.5rem;
   border: 1px solid #ccc;
   border-radius: 4px;
 }
-form button {
+.simple-form button {
   padding: 0.5rem 1rem;
   background-color: #28a745;
   color: white;
@@ -53,7 +61,7 @@ form button {
   border-radius: 4px;
   cursor: pointer;
 }
-form button:hover {
+.simple-form button:hover {
   background-color: #218838;
 }
 

--- a/templates/edit_data.html
+++ b/templates/edit_data.html
@@ -10,11 +10,13 @@
         <div class="alert alert-secondary mb-3">{{ field.text }}</div>
       {% else %}
         <div class="mb-3">
-          <div class="d-flex align-items-center">
-            <label for="{{ field.label|replace(' ', '_') }}" class="form-label me-3" style="width:150px;">
-              {{ field.label }}
-            </label>
-            <div class="flex-fill">
+          <div class="row g-2 align-items-center">
+            <div class="col-3">
+              <label for="{{ field.label|replace(' ', '_') }}" class="col-form-label fw-semibold">
+                {{ field.label }}
+              </label>
+            </div>
+            <div class="col">
               {% if field.type == 'dropdown' %}
                 <select id="{{ field.label|replace(' ', '_') }}" name="{{ field.label }}" class="form-select">
                   {% for opt in field.options %}
@@ -30,12 +32,16 @@
               {% endif %}
             </div>
             {% if field.uom %}
-              <span class="ms-2">{{ field.uom }}</span>
+              <div class="col-2 col-auto">
+                <span>{{ field.uom }}</span>
+              </div>
             {% endif %}
           </div>
           {% if field.help %}
-            <div class="form-text text-muted" style="margin-left:150px;">
-              {{ field.help }}
+            <div class="row">
+              <div class="col-9 offset-3">
+                <div class="form-text text-muted">{{ field.help }}</div>
+              </div>
             </div>
           {% endif %}
         </div>

--- a/templates/fill.html
+++ b/templates/fill.html
@@ -14,7 +14,7 @@
       {% else %}
         <div class="mb-3">
           <div class="row g-2 align-items-center">
-            <div class="col-md-3">
+            <div class="col-3">
               <label for="{{ field.label|replace(' ', '_') }}" class="col-form-label fw-semibold">
                 {{ field.label }}
               </label>
@@ -65,14 +65,14 @@
               {% endif %}
             </div>
             {% if field.uom %}
-              <div class="col-md-2 col-auto">
+              <div class="col-2 col-auto">
                 <span>{{ field.uom }}</span>
               </div>
             {% endif %}
           </div>
           {% if field.help %}
             <div class="row">
-              <div class="col-md-9 offset-md-3">
+              <div class="col-9 offset-3">
                 <div class="form-text text-muted">{{ field.help }}</div>
               </div>
             </div>

--- a/templates/upload.html
+++ b/templates/upload.html
@@ -2,7 +2,7 @@
 {% block title %}Upload Template{% endblock %}
 {% block content %}
   <h1>Upload New Template</h1>
-  <form method="post" enctype="multipart/form-data">
+  <form method="post" enctype="multipart/form-data" class="simple-form">
     <input type="file" name="template_file" accept="application/json">
     <button type="submit">Upload</button>
   </form>


### PR DESCRIPTION
## Summary
- Scope custom form CSS to a new `.simple-form` class so Bootstrap grids aren't overridden
- Use grid columns in `fill.html` and `edit_data.html` to keep labels, inputs, and units on one line
- Mark upload form with `.simple-form` class

## Testing
- `pytest`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68c8056b0acc832ca6fd7d73b1f700d2