### PR TITLE
Fix Firefox form styling by correcting CSS references

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -1,5 +1,4 @@
 <!DOCTYPE html>
-<link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
 <html lang="en">
 <head>
   <meta charset="utf-8">
@@ -8,7 +7,6 @@
   <link
     href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css"
     rel="stylesheet"
-    integrity="sha384-…"
     crossorigin="anonymous"
   >
   <!-- Your custom styles -->


### PR DESCRIPTION
## Summary
- remove stray link tag and invalid SRI hash preventing Bootstrap from loading in Firefox
- ensure base template links custom stylesheet once

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68c80953f81c832c89ba4e1c0dbfa493