### PR TITLE
Include editable UOM fields in templates

### DIFF
--- a/template_loader.py
+++ b/template_loader.py
@@ -18,5 +18,9 @@ def load_templates() -> dict[str, dict]:
         # template's `id` differs from the file name.
         data["_file"] = file
 
+        # Ensure every field has a UOM key so it can be easily edited later
+        for field in data.get("fields", []):
+            field.setdefault("uom", "")
+
         templates[name] = data
     return templates

--- a/templates/edit_template.html
+++ b/templates/edit_template.html
@@ -93,7 +93,8 @@
         const help = block.querySelector(`[name="help_${idx}"]`).value.trim();
         if (!label) return; // skip empty entries
         const f = { label: label, type: type };
-        if (uom) f.uom = uom;
+        // Always include the UOM field so it can be edited later
+        f.uom = uom;
         if (help) f.help = help;
         if (optionsVal) {
           f.options = optionsVal.split(',').map(o => o.trim()).filter(Boolean);


### PR DESCRIPTION
## Summary
- Ensure each loaded template field includes a `uom` key
- Always persist a UOM value when saving templates so users can edit it later

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c80de91e68832caf19d195567aecb6